### PR TITLE
Allow boundary theta_tilde in government welfare model

### DIFF
--- a/tests/test_government_model.py
+++ b/tests/test_government_model.py
@@ -1,0 +1,96 @@
+import numpy as np
+import pandas as pd
+
+from optimal_ipr.government import GovernmentModel
+
+
+class DummyRegulator:
+    def solve(self, scheme, bar_beta, theta_tilde, theta_winner, v, enforce_feasibility):
+        return 1.0, 1.0, 1.0
+
+    def debug_solve(self, scheme, bar_beta, theta_tilde, theta_winner, v):
+        return pd.DataFrame(
+            {
+                "beta": [1.0],
+                "innov_util": [1.0],
+                "imit_util_total": [0.0],
+                "tax_revenue": [1.0],
+                "public_revenue": [1.0],
+                "welfare": [1.0],
+            }
+        )
+
+
+def create_government_model(theta_tilde_value: float) -> GovernmentModel:
+    v_grid = np.array([1.0])
+    v_weights = np.array([1.0])
+    bar_grid = np.array([1.0])
+    master_lookup = np.array([[[[theta_tilde_value]]]])
+    master_winner = np.array([[[[theta_tilde_value]]]])
+    theta_points = np.array([0.0, 1.0])
+    theta_weights = np.array([0.5, 0.5])
+
+    def F(t):
+        return float(np.clip(t, 0.0, 1.0))
+
+    gm = GovernmentModel(
+        tau_d=0.2,
+        tau_f=0.1,
+        gov_prefs={},
+        reg_prefs={"utilitarian": {"phi": 1.0, "psi": 1.0}},
+        v_grid=v_grid,
+        v_weights=v_weights,
+        bar_grid=bar_grid,
+        master_lookup_table=master_lookup,
+        master_winner_table=master_winner,
+        theta_points=theta_points,
+        theta_weights=theta_weights,
+        enf_feas=False,
+        p=lambda th, v: np.ones_like(th, dtype=float),
+        c=lambda th, v: np.zeros_like(th, dtype=float),
+        Z=lambda b, v: np.zeros_like(b, dtype=float),
+        f=lambda t: np.ones_like(t, dtype=float),
+        F=F,
+        n_total_firms=2,
+        beta_grid=np.array([1.0]),
+        get_tau_d_index=lambda x: 0,
+        get_tau_f_index=lambda x: 0,
+        get_bar_beta_index=lambda x: 0,
+        get_v_index=lambda x: 0,
+        agent_types_grid=np.array([0.0, 1.0]),
+    )
+    gm.regulator_solver = DummyRegulator()
+    return gm
+
+
+def test_theta_tilde_boundaries():
+    gm = create_government_model(1.0)
+    res = gm._calculate_welfare_for_v(
+        w=lambda t: np.ones_like(t, dtype=float),
+        regulator_scheme="utilitarian",
+        bar_beta=1.0,
+        v=1.0,
+    )
+    assert res is not None
+    assert np.isclose(res["theta_tilde"], 1.0)
+    assert np.isclose(res["total_welfare_imitator"], 0.0)
+
+    gm.theta_tilde_slice[0, 0] = 0.0
+    gm.theta_winner_slice[0, 0] = 0.0
+    res0 = gm._calculate_welfare_for_v(
+        w=lambda t: np.ones_like(t, dtype=float),
+        regulator_scheme="utilitarian",
+        bar_beta=1.0,
+        v=1.0,
+    )
+    assert res0 is not None
+    assert np.isclose(res0["theta_tilde"], 0.0)
+
+    gm.theta_tilde_slice[0, 0] = 1.1
+    res_invalid = gm._calculate_welfare_for_v(
+        w=lambda t: np.ones_like(t, dtype=float),
+        regulator_scheme="utilitarian",
+        bar_beta=1.0,
+        v=1.0,
+    )
+    assert res_invalid is None

--- a/tests/test_subjective_probability.py
+++ b/tests/test_subjective_probability.py
@@ -2,12 +2,11 @@ import numpy as np
 import pytest
 from optimal_ipr.probability import build_subjective_probability
 
+
 def test_subjective_probability_smoke():
-    try:
-        p = build_subjective_probability(base_k=0.5, m_comp=25)
-    except FileNotFoundError:
-        pytest.skip("Missing data/top2000_SB2024.xlsx for theta distribution.")
-        return
+    F = lambda x: x
+    F_inv = lambda x: x
+    p = build_subjective_probability(base_k=0.5, m_comp=25, F=F, F_inv=F_inv)
 
     th = np.linspace(0, 1, 11)
     # increasing in theta for fixed v (weakly, numerically)


### PR DESCRIPTION
## Summary
- permit `theta_tilde` values of 0 and 1 in `GovernmentModel` so single-investor cases are handled
- add regression test for government boundary values and fix subjective probability test

## Testing
- `python -m black --check src/optimal_ipr/government/government_model.py tests/test_government_model.py tests/test_subjective_probability.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4f020b3ec83298eb02ca85c2568e5